### PR TITLE
[E-28480] Update jointoken

### DIFF
--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -53,7 +53,7 @@
         "toolTip": "Enter Jointoken obtained from CSP.",
         "constraints": {
           "required": true,
-          "regex": "^[a-zA-Z0-9_-]{44,44}$",
+          "regex": "^(?:[a-zA-Z0-9_\\-]+\\.)?[a-zA-Z0-9_\\-]{44}(?:\\.[a-zA-Z0-9_\\-]+)?$",
           "validationMessage": "Insert valid Jointoken."
         },
         "visible": "true"

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -325,7 +325,7 @@
       }
     },
     {
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2021-12-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[parameters('location')]",

--- a/main/nestedtemplates/nic-pip-existing.json
+++ b/main/nestedtemplates/nic-pip-existing.json
@@ -24,7 +24,7 @@
   "resources": [
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2021-12-01",
       "name": "[parameters('nicName')]",
       "location": "[parameters('location')]",
       "properties": {

--- a/main/nestedtemplates/nic-pip-none.json
+++ b/main/nestedtemplates/nic-pip-none.json
@@ -21,7 +21,7 @@
   "resources": [
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2021-12-01",
       "name": "[parameters('nicName')]",
       "location": "[parameters('location')]",
       "properties": {

--- a/main/nestedtemplates/publicip-new.json
+++ b/main/nestedtemplates/publicip-new.json
@@ -14,7 +14,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2021-12-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIpAddressName')]",
       "location": "[parameters('location')]",

--- a/main/nestedtemplates/vnet-new.json
+++ b/main/nestedtemplates/vnet-new.json
@@ -21,7 +21,7 @@
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2021-05-01",
+      "apiVersion": "2021-12-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {


### PR DESCRIPTION
Updated the Jointoken regex to support realm in the Jointoken
So we should support following formats:
```
<normal jt>
<realm id>.<normal jt>
<realm id>.<normal jt>.ibjt
```