### PR TITLE
fix: Fixed default value for "osDiskType" field in UI

### DIFF
--- a/main/createUiDefinition.json
+++ b/main/createUiDefinition.json
@@ -179,7 +179,7 @@
             "name": "osDiskType",
             "type": "Microsoft.Common.DropDown",
             "label": "OS Disk type",
-            "defaultValue": "Premium_LRS",
+            "defaultValue": "Premium SSD (Premium_LRS)",
             "constraints": {
               "allowedValues": [
                 {

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -549,7 +549,9 @@
             }
           },
           "zones": {
-            "value": ["[parameters('availabilityZones')]"]
+            "value": [
+              "[parameters('availabilityZones')]"
+            ]
           },
           "diagnosticsProfile": {
             "value": {


### PR DESCRIPTION
**- What was the issue**
The default value for `osDiskType` field was not selected in UI.

**- What I did to solve issue**
* In **Azure** default value must match the label, not the value.
* Updated default value for `osDiskType` that it works correctly in UI.