### PR TITLE
Added additional content for public ip to support AZ

### DIFF
--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -118,14 +118,6 @@
           "description": "Tier for the resource."
       }
     },
-    "ddosProtectionMode": {
-      "type": "string",
-      "allowedValues": [
-          "Disabled",
-          "Enabled",
-          "VirtualNetworkInherited"
-      ]
-    },
     "publicIpExistingRgName": {
       "type": "string",
       "defaultValue": "",
@@ -374,8 +366,8 @@
       "routingPreference": {
         "value": "[parameters('routingPreference')]"
       },
-      "ddosSettings": {
-        "value": "[variables('ddosSettings')]"
+      "tier": {
+        "value": "[parameters('tier')]"
       },
       "tagsByResource": {
         "value": "[parameters('tagsByResource')]"

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -79,6 +79,53 @@
         "description": "Name of the Public IP Address."
       }
     },
+    "sku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Basic",
+        "Standard"
+      ],
+      "metadata": {
+          "description": "Sku for the resource."
+        }
+    },
+    "routingPreference": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Routing Preference for the resource."
+      }
+    },
+    "publicIPAllocationMethod": {
+      "type": "string",
+      "allowedValues": [
+        "Static",
+        "Dynamic"
+      ],
+      "metadata": {
+          "description": "Public IP allocation method."
+      }
+    },
+    "tier": {
+      "type": "string",
+      "allowedValues": [
+          "Regional",
+          "Global"
+      ],
+      "defaultValue": "Regional",
+      "metadata": {
+          "description": "Tier for the resource."
+      }
+    },
+    "ddosProtectionMode": {
+      "type": "string",
+      "allowedValues": [
+          "Disabled",
+          "Enabled",
+          "VirtualNetworkInherited"
+      ]
+    },
     "publicIpExistingRgName": {
       "type": "string",
       "defaultValue": "",
@@ -305,6 +352,7 @@
     "nicPrimarySetupUrl": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/nic-pip-', variables('publicIpExistingOrNone'), '.json', parameters('_artifactsLocationSasToken')))]",
     "nsgName": "[concat(parameters('vmName'), '-securityGroup')]",
     "publicIpAddressType": "Dynamic",
+    "ddosSettings": "[if(empty(parameters('ddosProtectionMode')), json('null'), createObject('protectionMode', parameters('ddosProtectionMode')))]",
     "publicIpExistingOrNone": "[replace(parameters('publicIpNewOrExistingOrNone'), 'new', 'existing')]",
     "publicIpNewOrNone": "[replace(parameters('publicIpNewOrExistingOrNone'), 'existing', 'none')]",
     "publicIpNewParams": {
@@ -316,6 +364,18 @@
       },
       "publicIpAddressType": {
         "value": "[variables('publicIpAddressType')]"
+      },
+      "publicIPAllocationMethod": {
+        "value": "[parameters('publicIPAllocationMethod')]"
+      },
+      "sku": {
+        "value": "[parameters('sku')]"
+      },
+      "routingPreference": {
+        "value": "[parameters('routingPreference')]"
+      },
+      "ddosSettings": {
+        "value": "[variables('ddosSettings')]"
       },
       "tagsByResource": {
         "value": "[parameters('tagsByResource')]"

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -88,7 +88,7 @@
       ],
       "metadata": {
           "description": "Sku for the resource."
-        }
+      }
     },
     "routingPreference": {
       "type": "string",
@@ -104,18 +104,18 @@
         "Dynamic"
       ],
       "metadata": {
-          "description": "Public IP allocation method."
+        "description": "Public IP allocation method."
       }
     },
     "tier": {
       "type": "string",
       "allowedValues": [
-          "Regional",
-          "Global"
+        "Regional",
+        "Global"
       ],
       "defaultValue": "Regional",
       "metadata": {
-          "description": "Tier for the resource."
+        "description": "Tier for the resource."
       }
     },
     "ddosProtectionMode": {
@@ -127,7 +127,7 @@
         "VirtualNetworkInherited"
       ],
       "metadata": {
-          "description": "DDoS Protection Mode for the resource."
+        "description": "DDoS Protection Mode for the resource."
       }
     },
     "publicIpExistingRgName": {

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -623,21 +623,6 @@
           }
         }
       }
-    },
-    {
-      "name": "TestValidationStub",
-      "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2023-08-01",
-      "location": "[parameters('location')]",
-      "kind": "AzurePowerShell",
-      "properties": {
-        "azPowerShellVersion": "10.0",
-        "timeout": "PT1M",
-        "retentionInterval": "PT1H",
-        "cleanupPreference": "Always",
-        "arguments": "-availabilityOptions \"[parameters('availabilityOptions')]\" -zoneOptions \"[parameters('zoneOptions')]\"",
-        "scriptContent": "Write-Output \"OK\""
-      }
     }
   ]
 }

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -118,6 +118,18 @@
           "description": "Tier for the resource."
       }
     },
+    "ddosProtectionMode": {
+      "type": "string",
+      "defaultValue": "",
+      "allowedValues": [
+        "Disabled",
+        "Enabled",
+        "VirtualNetworkInherited"
+      ],
+      "metadata": {
+          "description": "DDoS Protection Mode for the resource."
+      }
+    },
     "publicIpExistingRgName": {
       "type": "string",
       "defaultValue": "",

--- a/main/mainTemplate.json
+++ b/main/mainTemplate.json
@@ -343,7 +343,6 @@
     },
     "nicPrimarySetupUrl": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/nic-pip-', variables('publicIpExistingOrNone'), '.json', parameters('_artifactsLocationSasToken')))]",
     "nsgName": "[concat(parameters('vmName'), '-securityGroup')]",
-    "publicIpAddressType": "Dynamic",
     "ddosSettings": "[if(empty(parameters('ddosProtectionMode')), json('null'), createObject('protectionMode', parameters('ddosProtectionMode')))]",
     "publicIpExistingOrNone": "[replace(parameters('publicIpNewOrExistingOrNone'), 'new', 'existing')]",
     "publicIpNewOrNone": "[replace(parameters('publicIpNewOrExistingOrNone'), 'existing', 'none')]",
@@ -353,9 +352,6 @@
       },
       "publicIpAddressName": {
         "value": "[parameters('publicIpAddressName')]"
-      },
-      "publicIpAddressType": {
-        "value": "[variables('publicIpAddressType')]"
       },
       "publicIPAllocationMethod": {
         "value": "[parameters('publicIPAllocationMethod')]"

--- a/main/nestedtemplates/publicip-new.json
+++ b/main/nestedtemplates/publicip-new.json
@@ -52,14 +52,6 @@
           "description": "Zones for the resource."
       }
     },
-    "ddosProtectionMode": {
-      "type": "string",
-      "allowedValues": [
-          "Disabled",
-          "Enabled",
-          "VirtualNetworkInherited"
-      ]
-    },
     "tagsByResource": {
       "type": "object",
       "defaultValue": {}

--- a/main/nestedtemplates/publicip-new.json
+++ b/main/nestedtemplates/publicip-new.json
@@ -9,27 +9,18 @@
       "type": "string"
     },
     "sku": {
-      "type": "string",
-      "metadata": {
-          "description": "Sku for the resource."
-        }
+      "type": "string"
     },
     "routingPreference": {
       "type": "string",
-      "defaultValue": "",
-      "metadata": {
-          "description": "Routing Preference for the resource."
-      }
+      "defaultValue": ""
     },
     "publicIPAllocationMethod": {
       "type": "string",
       "allowedValues": [
         "Static",
         "Dynamic"
-      ],
-      "metadata": {
-          "description": "Public IP allocation method."
-      }
+      ]
     },
     "tier": {
       "type": "string",
@@ -37,17 +28,15 @@
           "Regional",
           "Global"
       ],
-      "defaultValue": "Regional",
-      "metadata": {
-          "description": "Tier for the resource."
-      }
+      "defaultValue": "Regional"
     },
     "zones": {
       "type": "array",
-      "defaultValue": [],
-      "metadata": {
-          "description": "Zones for the resource."
-      }
+      "defaultValue": []
+    },
+    "ddosProtectionMode": {
+      "type": "string",
+      "defaultValue": ""
     },
     "tagsByResource": {
       "type": "object",

--- a/main/nestedtemplates/publicip-new.json
+++ b/main/nestedtemplates/publicip-new.json
@@ -11,6 +11,55 @@
     "publicIpAddressType": {
       "type": "string"
     },
+    "sku": {
+      "type": "string",
+      "metadata": {
+          "description": "Sku for the resource."
+        }
+    },
+    "routingPreference": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Routing Preference for the resource."
+      }
+    },
+    "publicIPAllocationMethod": {
+      "type": "string",
+      "allowedValues": [
+        "Static",
+        "Dynamic"
+      ],
+      "metadata": {
+          "description": "Public IP allocation method."
+      }
+    },
+    "tier": {
+      "type": "string",
+      "allowedValues": [
+          "Regional",
+          "Global"
+      ],
+      "defaultValue": "Regional",
+      "metadata": {
+          "description": "Tier for the resource."
+      }
+    },
+    "zones": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+          "description": "Zones for the resource."
+      }
+    },
+    "ddosProtectionMode": {
+      "type": "string",
+      "allowedValues": [
+          "Disabled",
+          "Enabled",
+          "VirtualNetworkInherited"
+      ]
+    },
     "tagsByResource": {
       "type": "object",
       "defaultValue": {}
@@ -22,6 +71,11 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIpAddressName')]",
       "location": "[parameters('location')]",
+      "zones": "[parameters('zones')]",
+      "sku": {
+        "name": "[parameters('sku')]",
+        "tier": "[parameters('tier')]"
+      },
       "tags": "[ if(contains(parameters('tagsByResource'), 'Microsoft.Network/publicIPAddresses'), parameters('tagsByResource')['Microsoft.Network/publicIPAddresses'], json('{}')) ]",
       "properties": {
         "publicIPAllocationMethod": "[parameters('publicIpAddressType')]"

--- a/main/nestedtemplates/publicip-new.json
+++ b/main/nestedtemplates/publicip-new.json
@@ -8,9 +8,6 @@
     "publicIpAddressName": {
       "type": "string"
     },
-    "publicIpAddressType": {
-      "type": "string"
-    },
     "sku": {
       "type": "string",
       "metadata": {
@@ -70,7 +67,7 @@
       },
       "tags": "[ if(contains(parameters('tagsByResource'), 'Microsoft.Network/publicIPAddresses'), parameters('tagsByResource')['Microsoft.Network/publicIPAddresses'], json('{}')) ]",
       "properties": {
-        "publicIPAllocationMethod": "[parameters('publicIpAddressType')]"
+        "publicIPAllocationMethod": "[parameters('publicIPAllocationMethod')]"
       }
     }
   ],


### PR DESCRIPTION
Added additional content for public ip to support deployment in AZ
And removed content of Test Validation Stub - to make it support in all regions

And reg vm sizes
The excludedValues property is not supported in the Microsoft.Compute.SizeSelector control. To exclude specific VM sizes, you need to explicitly define the sizes you want to allow using the allowedValues property. Unfortunately, this means you must list all the sizes you want to include, excluding the ones you don't need.

Steps to Exclude Specific Sizes:
Remove the excludedValues property from the constraints object.
Replace it with the allowedValues property.
List all the VM sizes you want to allow, excluding the ones you don't need.